### PR TITLE
Extend data truncation to 30 days

### DIFF
--- a/main.R
+++ b/main.R
@@ -35,7 +35,7 @@ raw_dat <- load_data(end_date = fdate)
 
 fcast_ids <- get_forecast_ids(dat = raw_dat,
                               forecast_date = fdate,
-                              max_trunc = 7)
+                              max_trunc = 30)
 
 raw_case_forecast <- load_hub_ensemble(forecast_date = (fdate + 2),
                                        locs = fcast_ids$id)


### PR DESCRIPTION
Extends the truncation period to include locations with hospital data in the last 30 days rather than the last 7.

This should fix the current problem where all locations are excluded given no data update for the last 2 weeks.